### PR TITLE
Bump runtime version: 23.08 -> 25.08

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/appdata_launchable_fix.patch
+++ b/appdata_launchable_fix.patch
@@ -1,0 +1,12 @@
+diff --git a/distribution/org.flarerpg.Flare.appdata.xml b/distribution/org.flarerpg.Flare.appdata.xml
+index c56272b3..1158847b 100644
+--- a/distribution/org.flarerpg.Flare.appdata.xml
++++ b/distribution/org.flarerpg.Flare.appdata.xml
+@@ -17,6 +17,7 @@
+ 		<p>Players may find or buy different items to protect themselves from attacks or boost their stats. These include potions, scrolls, weapons, armor, and magical artifacts. Along with the normal equipment, there are enchanted, rare, and unique pieces of gear that provide extra bonuses.</p>
+ 		<p>The Flare engine is licensed under GPL 3, whereas the Empyrean Campaign is licensed under CC-BY-SA 3.0. Both the engine and the game content are being actively developed, including new features, art, and content.</p>
+ 	</description>
++	<launchable type="desktop-id">flare.desktop</launchable>
+ 	<url type="homepage">http://flarerpg.org/</url>
+ 	<releases>
+ 		<release date="2022-12-10" version="1.14" />

--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,2 @@
 {
-    "automerge-flathubbot-prs": true
 }

--- a/org.flarerpg.Flare.yaml
+++ b/org.flarerpg.Flare.yaml
@@ -18,17 +18,6 @@ modules:
   - "shared-modules/SDL2/SDL2_image.json"
   - "shared-modules/SDL2/SDL2_ttf.json"
 
-  - name: SDL2_mixer
-    buildsystem: cmake-ninja
-    builddir: true
-    config-opts:
-      - -DSDL2MIXER_MOD=OFF
-      - -DSDL2MIXER_MIDI=OFF
-    sources:
-      - type: archive
-        url: https://github.com/libsdl-org/SDL_mixer/releases/download/release-2.8.1/SDL2_mixer-2.8.1.tar.gz
-        sha256: cb760211b056bfe44f4a1e180cc7cb201137e4d1572f2002cc1be728efd22660
-
   - name: flare-engine
     buildsystem: cmake-ninja
     config-opts:

--- a/org.flarerpg.Flare.yaml
+++ b/org.flarerpg.Flare.yaml
@@ -15,16 +15,8 @@ cleanup:
   - /app/games
   - /app/share/man
 modules:
-  - name: SDL2_image
-    buildsystem: cmake-ninja
-    builddir: true
-    config-opts:
-      - -DSDL2IMAGE_DEPS_SHARED=OFF
-      - -DSDL2IMAGE_STRICT=ON
-    sources:
-      - type: archive
-        url: https://github.com/libsdl-org/SDL_image/releases/download/release-2.8.8/SDL2_image-2.8.8.tar.gz
-        sha256: 2213b56fdaff2220d0e38c8e420cbe1a83c87374190cba8c70af2156097ce30a
+  - "shared-modules/SDL2/SDL2_image.json"
+  - "shared-modules/SDL2/SDL2_ttf.json"
 
   - name: SDL2_mixer
     buildsystem: cmake-ninja
@@ -36,16 +28,6 @@ modules:
       - type: archive
         url: https://github.com/libsdl-org/SDL_mixer/releases/download/release-2.8.1/SDL2_mixer-2.8.1.tar.gz
         sha256: cb760211b056bfe44f4a1e180cc7cb201137e4d1572f2002cc1be728efd22660
-
-  - name: SDL2_ttf
-    buildsystem: cmake-ninja
-    builddir: true
-    config-opts:
-      - -DSDL2TTF_HARFBUZZ=ON
-    sources:
-      - type: archive
-        url: https://github.com/libsdl-org/SDL_ttf/releases/download/release-2.24.0/SDL2_ttf-2.24.0.tar.gz
-        sha256: 0b2bf1e7b6568adbdbc9bb924643f79d9dedafe061fa1ed687d1d9ac4e453bfd
 
   - name: flare-engine
     buildsystem: cmake-ninja

--- a/org.flarerpg.Flare.yaml
+++ b/org.flarerpg.Flare.yaml
@@ -2,7 +2,7 @@ app-id: org.flarerpg.Flare
 rename-desktop-file: flare.desktop
 rename-icon: flare
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 command: flare.sh
 finish-args:
@@ -15,9 +15,42 @@ cleanup:
   - /app/games
   - /app/share/man
 modules:
+  - name: SDL2_image
+    buildsystem: cmake-ninja
+    builddir: true
+    config-opts:
+      - -DSDL2IMAGE_DEPS_SHARED=OFF
+      - -DSDL2IMAGE_STRICT=ON
+    sources:
+      - type: archive
+        url: https://github.com/libsdl-org/SDL_image/releases/download/release-2.8.8/SDL2_image-2.8.8.tar.gz
+        sha256: 2213b56fdaff2220d0e38c8e420cbe1a83c87374190cba8c70af2156097ce30a
+
+  - name: SDL2_mixer
+    buildsystem: cmake-ninja
+    builddir: true
+    config-opts:
+      - -DSDL2MIXER_MOD=OFF
+      - -DSDL2MIXER_MIDI=OFF
+    sources:
+      - type: archive
+        url: https://github.com/libsdl-org/SDL_mixer/releases/download/release-2.8.1/SDL2_mixer-2.8.1.tar.gz
+        sha256: cb760211b056bfe44f4a1e180cc7cb201137e4d1572f2002cc1be728efd22660
+
+  - name: SDL2_ttf
+    buildsystem: cmake-ninja
+    builddir: true
+    config-opts:
+      - -DSDL2TTF_HARFBUZZ=ON
+    sources:
+      - type: archive
+        url: https://github.com/libsdl-org/SDL_ttf/releases/download/release-2.24.0/SDL2_ttf-2.24.0.tar.gz
+        sha256: 0b2bf1e7b6568adbdbc9bb924643f79d9dedafe061fa1ed687d1d9ac4e453bfd
 
   - name: flare-engine
     buildsystem: cmake-ninja
+    config-opts:
+      - "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
     sources:
       - type: archive
         url: https://github.com/flareteam/flare-engine/archive/v1.14.tar.gz
@@ -36,6 +69,8 @@ modules:
 
   - name: flare-game
     buildsystem: cmake-ninja
+    config-opts:
+      - "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
     sources:
       - type: archive
         url: https://github.com/flareteam/flare-game/archive/v1.14.tar.gz

--- a/org.flarerpg.Flare.yaml
+++ b/org.flarerpg.Flare.yaml
@@ -51,6 +51,8 @@ modules:
           project-id: 21434
           url-template: https://github.com/flareteam/flare-game/archive/v$version.tar.gz
           stable-only: true
+      - type: patch
+        path: appdata_launchable_fix.patch
     post-install:
       - echo "flare --data-path=/app/share/games/flare" > /app/bin/flare.sh
       - chmod +x /app/bin/flare.sh


### PR DESCRIPTION
See: https://github.com/flareteam/flare-game/issues/1007

- 25.08 no longer provides the SDL2 versions of SDL_image, SDL_mixer, and SDL_ttf. So we fetch and build them here (thanks to the Freeciv team for the example: https://redmine.freeciv.org/issues/1685)
- Added workaround flag for minimum CMake version